### PR TITLE
Darken home image to improve contrast

### DIFF
--- a/src/Styles/Home.scss
+++ b/src/Styles/Home.scss
@@ -29,4 +29,5 @@ img {
   transform: translate(-50%, 0);
   width: 100vw;
   z-index: -1;
+  filter: brightness(50%)
 }


### PR DESCRIPTION
Use css `filter` property to reduce the brightness of home image to improve contrast. Feel free to adjust the brightness amount.